### PR TITLE
Match version with nirum

### DIFF
--- a/nirum/__init__.py
+++ b/nirum/__init__.py
@@ -2,5 +2,5 @@
 ~~~~~~~~~~~~~~~
 
 """
-__version_info__ = 0, 0, 2
+__version_info__ = 0, 1, 0
 __version__ = '.'.join(str(v) for v in __version_info__)


### PR DESCRIPTION
Match major version of python runtime wih nirum compiler at least. Current version of nirum compiler is [0.1.0][nirum-compiler-version].

[nirum-compiler-version]: https://github.com/spoqa/nirum/blob/master/nirum.cabal#L2
