### PR TITLE
Rename boxed to unboxed

### DIFF
--- a/nirum/serialize.py
+++ b/nirum/serialize.py
@@ -8,17 +8,23 @@ import uuid
 
 __all__ = (
     'serialize_boxed_type', 'serialize_meta',
-    'serialize_record_type', 'serialize_union_type',
+    'serialize_record_type', 'serialize_unboxed_type',
+    'serialize_union_type',
 )
 
 
-def serialize_boxed_type(data):
+def serialize_unboxed_type(data):
     value = data.value
     serialize = getattr(value, '__nirum_serialize__', None)
     if callable(serialize):
         return serialize()
     else:
         return serialize_meta(value)
+
+
+serialize_boxed_type = serialize_unboxed_type
+# FIXME: serialize_boxed_type() is for backward compatibility;
+#        remove it in the near future
 
 
 def serialize_type_with_names(data, names):

--- a/nirum/validate.py
+++ b/nirum/validate.py
@@ -6,7 +6,7 @@ import typing
 
 __all__ = (
     'validate_boxed_type', 'validate_record_type', 'validate_type',
-    'validate_union_type',
+    'validate_unboxed_type', 'validate_union_type',
 )
 
 
@@ -24,11 +24,16 @@ def validate_type(data, type_):
     return instance_check
 
 
-def validate_boxed_type(boxed, type_hint):
-    if not isinstance(boxed, type_hint):
+def validate_unboxed_type(unboxed, type_hint):
+    if not isinstance(unboxed, type_hint):
         raise TypeError('{0} expected, found: {1}'.format(type_hint,
-                                                          type(boxed)))
-    return boxed
+                                                          type(unboxed)))
+    return unboxed
+
+
+validate_boxed_type = validate_unboxed_type
+# FIXME: validate_boxed_type() is for backward compatibility;
+#        remove it in the near future
 
 
 def validate_record_type(record):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,19 +5,19 @@ import uuid
 
 from pytest import fixture
 
-from nirum.serialize import serialize_record_type, serialize_boxed_type
-from nirum.deserialize import deserialize_record_type, deserialize_boxed_type
-from nirum.validate import (validate_boxed_type, validate_record_type,
+from nirum.serialize import serialize_record_type, serialize_unboxed_type
+from nirum.deserialize import deserialize_record_type, deserialize_unboxed_type
+from nirum.validate import (validate_unboxed_type, validate_record_type,
                             validate_union_type)
 from nirum.constructs import NameDict, name_dict_type
 
 
 class Token:
 
-    __nirum_boxed_type__ = uuid.UUID
+    __nirum_inner_type__ = uuid.UUID
 
     def __init__(self, value: uuid.UUID) -> None:
-        validate_boxed_type(value, uuid.UUID)
+        validate_unboxed_type(value, uuid.UUID)
         self.value = value
 
     def __eq__(self, other) -> bool:
@@ -27,13 +27,13 @@ class Token:
         return hash(self.value)
 
     def __nirum_serialize__(self) -> typing.Mapping[str, typing.Any]:
-        return serialize_boxed_type(self)
+        return serialize_unboxed_type(self)
 
     @classmethod
     def __nirum_deserialize__(
         cls: type, value: typing.Mapping[str, typing.Any]
     ) -> 'Token':
-        return deserialize_boxed_type(cls, value)
+        return deserialize_unboxed_type(cls, value)
 
     def __hash__(self) -> int:  # noqa
         return hash((self.__class__, self.value))
@@ -41,10 +41,10 @@ class Token:
 
 class Offset:
 
-    __nirum_boxed_type__ = float
+    __nirum_inner_type__ = float
 
     def __init__(self, value: float) -> None:
-        validate_boxed_type(value, float)
+        validate_unboxed_type(value, float)
         self.value = value
 
     def __eq__(self, other) -> bool:
@@ -54,13 +54,13 @@ class Offset:
         return hash(self.value)
 
     def __nirum_serialize__(self) -> typing.Mapping[str, typing.Any]:
-        return serialize_boxed_type(self)
+        return serialize_unboxed_type(self)
 
     @classmethod
     def __nirum_deserialize__(
         cls: type, value: typing.Mapping[str, typing.Any]
     ) -> 'Offset':
-        return deserialize_boxed_type(cls, value)
+        return deserialize_unboxed_type(cls, value)
 
     def __hash__(self) -> int:  # noqa
         return hash((self.__class__, self.value))
@@ -250,13 +250,13 @@ class Location:
 
 
 @fixture
-def fx_boxed_type():
+def fx_unboxed_type():
     return Offset
 
 
 @fixture
-def fx_offset(fx_boxed_type):
-    return fx_boxed_type(1.2)
+def fx_offset(fx_unboxed_type):
+    return fx_unboxed_type(1.2)
 
 
 @fixture
@@ -265,8 +265,8 @@ def fx_record_type():
 
 
 @fixture
-def fx_point(fx_record_type, fx_boxed_type):
-    return fx_record_type(fx_boxed_type(3.14), fx_boxed_type(1.592))
+def fx_point(fx_record_type, fx_unboxed_type):
+    return fx_record_type(fx_unboxed_type(3.14), fx_unboxed_type(1.592))
 
 
 @fixture
@@ -286,10 +286,10 @@ def fx_rectangle(fx_rectangle_type, fx_point):
 
 class A:
 
-    __nirum_boxed_type__ = str
+    __nirum_inner_type__ = str
 
     def __init__(self, value: str) -> None:
-        validate_boxed_type(value, str)
+        validate_unboxed_type(value, str)
         self.value = value  # type: Text
 
     def __eq__(self, other) -> bool:
@@ -300,13 +300,13 @@ class A:
         return hash(self.value)
 
     def __nirum_serialize__(self) -> str:
-        return serialize_boxed_type(self)
+        return serialize_unboxed_type(self)
 
     @classmethod
     def __nirum_deserialize__(
         cls: type, value: typing.Mapping[str, typing.Any]
     ) -> 'A':
-        return deserialize_boxed_type(cls, value)
+        return deserialize_unboxed_type(cls, value)
 
     def __repr__(self) -> str:
         return '{0.__module__}.{0.__qualname__}({1!r})'.format(
@@ -316,10 +316,10 @@ class A:
 
 class B:
 
-    __nirum_boxed_type__ = A
+    __nirum_inner_type__ = A
 
     def __init__(self, value: A) -> None:
-        validate_boxed_type(value, A)
+        validate_unboxed_type(value, A)
         self.value = value  # type: A
 
     def __eq__(self, other) -> bool:
@@ -330,13 +330,13 @@ class B:
         return hash(self.value)
 
     def __nirum_serialize__(self) -> str:
-        return serialize_boxed_type(self)
+        return serialize_unboxed_type(self)
 
     @classmethod
     def __nirum_deserialize__(
         cls: type, value: typing.Mapping[str, typing.Any]
     ) -> 'B':
-        return deserialize_boxed_type(cls, value)
+        return deserialize_unboxed_type(cls, value)
 
     def __repr__(self) -> str:
         return '{0.__module__}.{0.__qualname__}({1!r})'.format(
@@ -346,10 +346,10 @@ class B:
 
 class C:
 
-    __nirum_boxed_type__ = B
+    __nirum_inner_type__ = B
 
     def __init__(self, value: B) -> None:
-        validate_boxed_type(value, B)
+        validate_unboxed_type(value, B)
         self.value = value  # type: B
 
     def __eq__(self, other) -> bool:
@@ -360,13 +360,13 @@ class C:
         return hash(self.value)
 
     def __nirum_serialize__(self) -> str:
-        return serialize_boxed_type(self)
+        return serialize_unboxed_type(self)
 
     @classmethod
     def __nirum_deserialize__(
         cls: type, value: typing.Mapping[str, typing.Any]
     ) -> 'C':
-        return deserialize_boxed_type(cls, value)
+        return deserialize_unboxed_type(cls, value)
 
     def __repr__(self) -> str:
         return '{0.__module__}.{0.__qualname__}({1!r})'.format(
@@ -375,7 +375,7 @@ class C:
 
 
 @fixture
-def fx_layered_boxed_types():
+def fx_layered_unboxed_types():
     return A, B, C
 
 

--- a/tests/deserialize_test.py
+++ b/tests/deserialize_test.py
@@ -6,29 +6,29 @@ import typing
 from pytest import raises, mark
 
 from nirum.serialize import serialize_record_type
-from nirum.deserialize import (deserialize_boxed_type, deserialize_meta,
+from nirum.deserialize import (deserialize_unboxed_type, deserialize_meta,
                                deserialize_tuple_type,
                                deserialize_record_type, deserialize_union_type,
                                deserialize_optional, deserialize_primitive)
 
 
-def test_deserialize_boxed_type(fx_boxed_type, fx_token_type):
+def test_deserialize_unboxed_type(fx_unboxed_type, fx_token_type):
     v = 3.14
-    assert fx_boxed_type(v) == deserialize_boxed_type(fx_boxed_type, v)
+    assert fx_unboxed_type(v) == deserialize_unboxed_type(fx_unboxed_type, v)
     uuid_ = uuid.uuid4()
     t = str(uuid_)
-    assert fx_token_type(uuid_) == deserialize_boxed_type(fx_token_type, t)
+    assert fx_token_type(uuid_) == deserialize_unboxed_type(fx_token_type, t)
 
 
-def test_deserialize_record_type(fx_boxed_type, fx_record_type):
+def test_deserialize_record_type(fx_unboxed_type, fx_record_type):
     with raises(ValueError):
         deserialize_record_type(fx_record_type, {})
 
     with raises(ValueError):
         deserialize_record_type(fx_record_type, {'_type': 'hello'})
 
-    left = fx_boxed_type(1.1)
-    top = fx_boxed_type(2.2)
+    left = fx_unboxed_type(1.1)
+    top = fx_unboxed_type(2.2)
     deserialized = deserialize_record_type(
         fx_record_type, {'_type': 'point', 'x': left.value, 'top': top.value}
     )
@@ -72,9 +72,9 @@ def test_deserialize_meta_error():
         deserialize_meta(None, {})
 
 
-def test_deserialize_meta_record(fx_boxed_type, fx_record_type, fx_point):
-    left = fx_boxed_type(1.1)
-    top = fx_boxed_type(2.2)
+def test_deserialize_meta_record(fx_unboxed_type, fx_record_type, fx_point):
+    left = fx_unboxed_type(1.1)
+    top = fx_unboxed_type(2.2)
     d = {'_type': 'point', 'x': left.value, 'top': top.value}
     meta = deserialize_meta(fx_record_type, d)
     record = deserialize_record_type(fx_record_type, d)
@@ -96,20 +96,20 @@ def test_deserialize_meta_union(fx_rectangle_type, fx_point, fx_shape_type):
     assert meta_from_shape == meta
 
 
-def test_deserialize_meta_boxed(fx_boxed_type, fx_record_type, fx_point,
-                                fx_token_type):
+def test_deserialize_meta_unboxed(fx_unboxed_type, fx_record_type, fx_point,
+                                  fx_token_type):
     v = 3.14
-    meta = deserialize_meta(fx_boxed_type, v)
-    boxed = fx_boxed_type(v)
-    assert meta == boxed
+    meta = deserialize_meta(fx_unboxed_type, v)
+    unboxed = fx_unboxed_type(v)
+    assert meta == unboxed
     v = uuid.uuid4()
     meta = deserialize_meta(fx_token_type, str(v))
-    boxed = fx_token_type(v)
-    assert meta == boxed
+    unboxed = fx_token_type(v)
+    assert meta == unboxed
 
 
-def test_deserialize_multiple_boxed_type(fx_layered_boxed_types):
-    A, B, C = fx_layered_boxed_types
+def test_deserialize_multiple_unboxed_type(fx_layered_unboxed_types):
+    A, B, C = fx_layered_unboxed_types
     assert B.__nirum_deserialize__('lorem') == B(A('lorem'))
     assert C.__nirum_deserialize__('x') == C(B(A('x')))
     with raises(ValueError):

--- a/tests/serialize_test.py
+++ b/tests/serialize_test.py
@@ -4,18 +4,18 @@ import uuid
 
 from pytest import mark
 
-from nirum.serialize import (serialize_boxed_type, serialize_record_type,
+from nirum.serialize import (serialize_unboxed_type, serialize_record_type,
                              serialize_meta, serialize_union_type)
 
 
-def test_serialize_boxed_type(fx_offset, fx_token_type):
-    assert serialize_boxed_type(fx_offset) == fx_offset.value
+def test_serialize_unboxed_type(fx_offset, fx_token_type):
+    assert serialize_unboxed_type(fx_offset) == fx_offset.value
     token = uuid.uuid4()
-    assert serialize_boxed_type(fx_token_type(token)) == str(token)
+    assert serialize_unboxed_type(fx_token_type(token)) == str(token)
 
 
-def test_serialize_layered_boxed_type(fx_layered_boxed_types):
-    actual = fx_layered_boxed_types[1](fx_layered_boxed_types[0]('test'))
+def test_serialize_layered_unboxed_type(fx_layered_unboxed_types):
+    actual = fx_layered_unboxed_types[1](fx_layered_unboxed_types[0]('test'))
     assert actual.__nirum_serialize__() == 'test'
 
 
@@ -30,7 +30,7 @@ def test_serialize_union_type(fx_point, fx_offset, fx_circle_type,
     s = {
         '_type': 'shape', '_tag': 'circle',
         'origin': serialize_record_type(fx_point),
-        'radius': serialize_boxed_type(fx_offset)
+        'radius': serialize_unboxed_type(fx_offset)
     }
     assert serialize_union_type(circle) == s
     rectangle = fx_rectangle_type(fx_point, fx_point)
@@ -42,8 +42,8 @@ def test_serialize_union_type(fx_point, fx_offset, fx_circle_type,
     assert serialize_union_type(rectangle) == s
 
 
-def test_multiple_boxed_type(fx_layered_boxed_types):
-    A, B, _ = fx_layered_boxed_types
+def test_multiple_unboxed_type(fx_layered_unboxed_types):
+    A, B, _ = fx_layered_unboxed_types
     assert B(A('hello')).value.value == 'hello'
     assert B(A('lorem')).__nirum_serialize__() == 'lorem'
 
@@ -89,10 +89,10 @@ def test_serialize_meta_set(d, expect):
         e in serialized
 
 
-def test_serialize_meta_set_of_record(fx_record_type, fx_boxed_type,
+def test_serialize_meta_set_of_record(fx_record_type, fx_unboxed_type,
                                       fx_offset):
     record = fx_record_type(fx_offset, fx_offset)
-    record2 = fx_record_type(fx_boxed_type(1.1), fx_boxed_type(1.2))
+    record2 = fx_record_type(fx_unboxed_type(1.1), fx_unboxed_type(1.2))
     serialize_result = serialize_meta({record, record2})
     assert record.__nirum_serialize__() in serialize_result
     assert record2.__nirum_serialize__() in serialize_result

--- a/tests/validate_test.py
+++ b/tests/validate_test.py
@@ -2,14 +2,14 @@ import decimal
 
 from pytest import raises
 
-from nirum.validate import (validate_boxed_type, validate_record_type,
+from nirum.validate import (validate_unboxed_type, validate_record_type,
                             validate_union_type)
 
 
-def test_validate_boxed_type():
-    assert validate_boxed_type(3.14, float)
+def test_validate_unboxed_type():
+    assert validate_unboxed_type(3.14, float)
     with raises(TypeError):
-        validate_boxed_type('hello', float)
+        validate_unboxed_type('hello', float)
 
 
 def test_validate_record_type(fx_point, fx_record_type, fx_offset,
@@ -37,16 +37,16 @@ def test_validate_union_type(fx_rectangle, fx_rectangle_type, fx_point):
         validate_union_type(fx_rectangle_type(1, 1))
 
 
-def test_validate_layered_boxed_types(fx_layered_boxed_types):
-    A, B, C = fx_layered_boxed_types
-    assert validate_boxed_type('test', str)
-    assert validate_boxed_type(A('test'), A)
-    assert validate_boxed_type(B(A('test')), B)
+def test_validate_layered_unboxed_types(fx_layered_unboxed_types):
+    A, B, C = fx_layered_unboxed_types
+    assert validate_unboxed_type('test', str)
+    assert validate_unboxed_type(A('test'), A)
+    assert validate_unboxed_type(B(A('test')), B)
     with raises(TypeError):
-        assert validate_boxed_type('test', A)
+        assert validate_unboxed_type('test', A)
 
     with raises(TypeError):
-        assert validate_boxed_type('test', B)
+        assert validate_unboxed_type('test', B)
 
     with raises(TypeError):
-        assert validate_boxed_type(A('test'), B)
+        assert validate_unboxed_type(A('test'), B)


### PR DESCRIPTION
It aims to fix spoqa/nirum#65 and is required by spoqa/nirum#81.  Note that the existing `serialize_boxed_type()`/`deserialize_boxed_type()`/`validate_boxed_type()` functions are preserved for backward compatibility.  Also, although compiler now generates `__nirum_inner_type__` attribute instead of `__nirum_boxed_type__`, the runtime still looks up both for backward compatibility.