### PR TITLE
Map types

### DIFF
--- a/nirum/datastructures.py
+++ b/nirum/datastructures.py
@@ -1,0 +1,49 @@
+""":mod:`nirum.datastructures` --- Immutable data structures
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+"""
+import collections
+
+__all__ = 'Map',
+
+
+class Map(collections.Mapping):
+    """As Python standard library doesn't provide immutable :class:`dict`,
+    Nirum runtime itself need to define one.
+
+    """
+
+    __slots__ = 'value',
+
+    def __init__(self, *args, **kwargs):
+        # TODO: type check on elements
+        self.value = dict(*args, **kwargs)
+
+    def __iter__(self):
+        return iter(self.value)
+
+    def __len__(self):
+        return len(self.value)
+
+    def __getitem__(self, key):
+        return self.value[key]
+
+    def __contains__(self, key):
+        return key in self.value
+
+    def __reduce__(self):
+        return type(self), (self.value,)
+
+    def __bool__(self):
+        return bool(self.value)
+
+    __nonzero__ = __bool__
+
+    def __repr__(self):
+        if self:
+            items = sorted(self.value.items())
+            format_item = '{0!r}: {1!r}'.format
+            args = '{' + ', '.join(format_item(*item) for item in items) + '}'
+        else:
+            args = ''
+        return '{0.__module__}.{0.__name__}({1})'.format(type(self), args)

--- a/nirum/serialize.py
+++ b/nirum/serialize.py
@@ -2,6 +2,7 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 """
+import collections
 import datetime
 import decimal
 import uuid
@@ -67,11 +68,11 @@ def serialize_meta(data):
         d = str(data)
     elif isinstance(data, set) or isinstance(data, list):
         d = [serialize_meta(e) for e in data]
-    elif isinstance(data, dict):
-        d = {
-            k: serialize_meta(v)
+    elif isinstance(data, collections.Mapping):
+        d = [
+            {'key': serialize_meta(k), 'value': serialize_meta(v)}
             for k, v in data.items()
-        }
+        ]
     else:
         d = data
     return d

--- a/nirum/validate.py
+++ b/nirum/validate.py
@@ -2,6 +2,7 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 """
+import collections
 import typing
 
 from ._compat import get_abstract_param_types, get_union_types, is_union_type
@@ -14,12 +15,13 @@ __all__ = (
 
 def validate_type(data, type_):
     instance_check = False
-    abstract_types = {typing.AbstractSet, typing.Sequence}
+    abstract_types = {typing.AbstractSet, typing.Sequence, typing.Mapping}
     if hasattr(type_, '__origin__') and type_.__origin__ in abstract_types:
         param_type = get_abstract_param_types(type_)
         imp_types = {
             typing.AbstractSet: set,
             typing.Sequence: list,
+            typing.Mapping: collections.Mapping,
         }
         instance_check = isinstance(data, imp_types[type_.__origin__]) and \
             all(isinstance(item, param_type[0]) for item in data)

--- a/tests/datastructures_test.py
+++ b/tests/datastructures_test.py
@@ -1,0 +1,70 @@
+import collections
+import pickle
+
+from pytest import raises
+
+from nirum.datastructures import Map
+
+
+def test_map_init():
+    assert list(Map()) == []
+    assert (sorted(Map([('a', 1), ('b', 2)]).items()) ==
+            sorted(Map({'a': 1, 'b': 2}).items()) ==
+            sorted(Map(Map({'a': 1, 'b': 2})).items()) ==
+            sorted(Map(a=1, b=2).items()) ==
+            sorted(Map([('a', 1)], b=2).items()) ==
+            sorted(Map({'a': 1}, b=2).items()) ==
+            sorted(Map(Map([('a', 1)]), b=2).items()) ==
+            [('a', 1), ('b', 2)])
+    assert isinstance(Map(), collections.Mapping)
+    assert not isinstance(Map(), collections.MutableMapping)
+
+
+def test_map_iter():
+    assert list(Map()) == []
+    assert list(Map(a=1)) == ['a']
+    assert list(Map(a=1, b=2)) in (['a', 'b'], ['b', 'a'])
+
+
+def test_map_len():
+    assert len(Map()) == 0
+    assert len(Map(a=1)) == 1
+    assert len(Map(a=1, b=2)) == 2
+
+
+def test_map_getitem():
+    m = Map(a=1, b=2)
+    assert m['a'] == m.get('a') == m.get('a', 0) == 1
+    assert m['b'] == m.get('b') == m.get('b', 0) == 2
+    with raises(KeyError):
+        m['c']
+    assert m.get('c') is None
+    assert m.get('c', 0) == 0
+
+
+def test_map_contains():
+    m = Map(a=1, b=2)
+    assert 'a' in m
+    assert 'b' in m
+    assert 'c' not in m
+
+
+def test_map_pickle():
+    def p(v):
+        assert pickle.loads(pickle.dumps(v)) == v
+    p(Map())
+    p(Map(a=1))
+    p(Map(a=1, b=2))
+    p(Map(d=Map(a=1, b=2)))
+
+
+def test_map_bool():
+    assert not Map()
+    assert Map(a=1)
+    assert Map(a=1, b=2)
+
+
+def test_map_repr():
+    assert repr(Map()) == 'nirum.datastructures.Map()'
+    assert repr(Map(a=1)) == "nirum.datastructures.Map({'a': 1})"
+    assert repr(Map(a=1, b=2)) == "nirum.datastructures.Map({'a': 1, 'b': 2})"

--- a/tests/nirum_schema.py
+++ b/tests/nirum_schema.py
@@ -15,6 +15,6 @@ def import_nirum_fixture():
         [
             'A', 'B', 'C', 'Circle', 'Location', 'MusicService',
             'MusicServiceClient', 'Offset', 'Point', 'Rectangle', 'Shape',
-            'Token',
+            'Token', 'ComplexKeyMap',
         ]
     )

--- a/tests/py2_nirum.py
+++ b/tests/py2_nirum.py
@@ -400,3 +400,49 @@ class Token:
     @classmethod
     def __nirum_deserialize__(cls, value):
         return deserialize_unboxed_type(cls, value)
+
+
+class ComplexKeyMap(object):
+
+    __slots__ = (
+        'value',
+    )
+    __nirum_record_behind_name__ = (
+        'complex_key_map'
+    )
+    __nirum_field_types__ = {
+        'value': typing.Mapping[Point, Point]
+    }
+    __nirum_field_names__ = name_dict_type([
+        ('value', 'value')
+    ])
+
+    def __init__(self, value):
+        self.value = value
+        validate_record_type(self)
+
+    def __repr__(self):
+        return '{0}({1})'.format(
+            (type(self).__module__ + '.' + type(self).__name__),
+            ', '.join('{}={}'.format(attr, getattr(self, attr))
+                      for attr in self.__slots__)
+        )
+
+    def __eq__(self, other):
+        return isinstance(other, ComplexKeyMap) and all(
+            getattr(self, attr) == getattr(other, attr)
+            for attr in self.__slots__
+        )
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __nirum_serialize__(self):
+        return serialize_record_type(self)
+
+    @classmethod
+    def __nirum_deserialize__(cls, value):
+        return deserialize_record_type(cls, value)
+
+    def __hash__(self):
+        return hash((self.value,))

--- a/tests/py3_nirum.py
+++ b/tests/py3_nirum.py
@@ -403,3 +403,50 @@ class Token:
 
     def __hash__(self) -> int:  # noqa
         return hash((self.__class__, self.value))
+
+
+class ComplexKeyMap(object):
+    # TODO: docstring
+
+    __slots__ = (
+        'value',
+    )
+    __nirum_record_behind_name__ = (
+        'complex_key_map'
+    )
+    __nirum_field_types__ = {
+        'value': typing.Mapping[Point, Point]
+    }
+    __nirum_field_names__ = name_dict_type([
+        ('value', 'value')
+    ])
+
+    def __init__(self, value: typing.Mapping[Point, Point]) -> None:
+        self.value = value
+        validate_record_type(self)
+
+    def __repr__(self) -> bool:
+        return '{0}({1})'.format(
+            typing._type_repr(type(self)),
+            ', '.join('{}={}'.format(attr, getattr(self, attr))
+                      for attr in self.__slots__)
+        )
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, ComplexKeyMap) and all(
+            getattr(self, attr) == getattr(other, attr)
+            for attr in self.__slots__
+        )
+
+    def __ne__(self, other) -> bool:
+        return not self == other
+
+    def __nirum_serialize__(self) -> typing.Mapping[str, typing.Any]:
+        return serialize_record_type(self)
+
+    @classmethod
+    def __nirum_deserialize__(cls: type, value) -> 'ComplexKeyMap':
+        return deserialize_record_type(cls, value)
+
+    def __hash__(self) -> int:
+        return hash((self.value,))


### PR DESCRIPTION
Although the runtime library already had had serializer and deserializer for maps, they weren't correctly implemented according to the spec.  Map should be encoded as an array of objects e.g. `[{"key": ..., "value": ...}]` since keys can be more than primitive types, but it had encoded map as an object e.g. `{...: ...}`.

Also, as Python doesn't offset immutable `dict`, I implemented a simple immutable `dict`.  Though its name is `Map` to follow Nirum's own terms.