### PR TITLE
Use abstract class to compare with immutable type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,5 +13,6 @@ Release on March 20, 2017.
   [:issue:`66`]
 - Added :class:`nirum.datastructures.List` which is an immutable list.
   [:issue:`49`]
+- Compare type with its abstract type in :func:`nirum.validate.validate_type`.
 
 __ https://github.com/spoqa/nirum/blob/f1629787f45fef17eeab8b4f030c34580e0446b8/docs/serialization.md

--- a/nirum/validate.py
+++ b/nirum/validate.py
@@ -19,8 +19,8 @@ def validate_type(data, type_):
     if hasattr(type_, '__origin__') and type_.__origin__ in abstract_types:
         param_type = get_abstract_param_types(type_)
         imp_types = {
-            typing.AbstractSet: set,
-            typing.Sequence: list,
+            typing.AbstractSet: collections.Set,
+            typing.Sequence: collections.Sequence,
             typing.Mapping: collections.Mapping,
         }
         instance_check = isinstance(data, imp_types[type_.__origin__]) and \

--- a/tests/validate_test.py
+++ b/tests/validate_test.py
@@ -4,6 +4,7 @@ import typing
 from pytest import raises
 from six import text_type
 
+from nirum.datastructures import List
 from nirum.validate import (validate_unboxed_type, validate_record_type,
                             validate_union_type, validate_type)
 
@@ -56,3 +57,9 @@ def test_validate_layered_boxed_types(fx_layered_boxed_types):
 
 def test_validate_abstract_set():
     assert validate_type({1, 2, 3}, typing.AbstractSet[int])
+    assert validate_type(frozenset([1, 2, 3]), typing.AbstractSet[int])
+
+
+def test_validate_list():
+    assert validate_type([1, 2, 3], typing.Sequence[int])
+    assert validate_type(List([1, 2, 3]), typing.Sequence[int])


### PR DESCRIPTION
Since immutable data type (`frozenset`, `nirum.datastructures.List`) isn't equivalent to `set` or `list`, `validate_type` have to compare value with its abstract class. 

https://github.com/spoqa/nirum/pull/123 test will be succeeded, after this PR merged & released.