### PR TITLE
Catch method error types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,6 @@ Release on May 2nd, 2017.
 Version 0.5.0
 -------------
 
-- Service methods should be possible to specify its error type. [:issue:`71`]
+- Service methods became able to specify its error type. [:issue:`71`]
 
 __ https://github.com/spoqa/nirum/blob/f1629787f45fef17eeab8b4f030c34580e0446b8/docs/serialization.md

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,7 +29,6 @@ Release on May 2nd, 2017.
 Version 0.5.0
 -------------
 
-To be released.
-
+- Service methods should be possible to specify its error type. [:issue:`71`]
 
 __ https://github.com/spoqa/nirum/blob/f1629787f45fef17eeab8b4f030c34580e0446b8/docs/serialization.md

--- a/nirum/rpc.py
+++ b/nirum/rpc.py
@@ -395,11 +395,11 @@ class Client:
         for header_name, header_content in headers:
             request.add_header(header_name, header_content)
         response = self.opener.open(request, None)
-        response_text = response.read()
+        response_text = response.read().decode('utf-8')
         if 200 <= response.code < 300:
-            return response_text.decode('utf-8')
+            return response_text
         else:
-            raise UnexpectedNirumResponseError(response_text.decode('utf-8'))
+            raise UnexpectedNirumResponseError(response_text)
 
 
 # To eliminate imported vars from being overridden by

--- a/nirum/rpc.py
+++ b/nirum/rpc.py
@@ -166,9 +166,9 @@ class WsgiApp:
         except (NirumProcedureArgumentValueError,
                 NirumProcedureArgumentRequiredError) as e:
             return self.error(400, request, message=str(e))
-        method_error = self.service.__nirum_method_error_types__[
-            method_facial_name
-        ]
+        method_error = self.service.__nirum_method_error_types__.get(
+            method_facial_name, ()
+        )
         try:
             result = service_method(**arguments)
         except method_error as e:

--- a/tests/py3_nirum.py
+++ b/tests/py3_nirum.py
@@ -5,10 +5,11 @@ import json
 import uuid
 
 from nirum.serialize import (serialize_record_type, serialize_unboxed_type,
-                             serialize_meta)
+                             serialize_meta, serialize_union_type)
 from nirum.deserialize import (deserialize_record_type,
                                deserialize_unboxed_type,
-                               deserialize_meta)
+                               deserialize_meta,
+                               deserialize_union_type)
 from nirum.validate import (validate_unboxed_type, validate_record_type,
                             validate_union_type)
 from nirum.constructs import NameDict, name_dict_type
@@ -305,6 +306,98 @@ class C:
         )
 
 
+class HelloError(Exception):
+    # compiled code
+
+    __nirum_union_behind_name__ = 'hello_error'
+    __nirum_field_names__ = name_dict_type([
+        ('unknown', 'unknown'),
+        ('bad_request', 'bad_request')
+    ])
+
+    class Tag(enum.Enum):
+        unknown = 'unknown'
+        bad_request = 'bad_request'
+
+    def __init__(self, *args, **kwargs):
+        raise NotImplementedError(
+            "{0} cannot be instantiated "
+            "since it is an abstract class.  Instantiate a concrete subtype "
+            "of it instead.".format(typing._type_repr(type(self)))
+        )
+
+    def __nirum_serialize__(self) -> typing.Mapping[str, typing.Any]:
+        return serialize_union_type(self)
+
+    @classmethod
+    def __nirum_deserialize__(
+        cls: type, value
+    ) -> 'HelloError':
+        return deserialize_union_type(cls, value)
+
+
+class Unknown(HelloError):
+    # compiled code
+
+    __slots__ = ()
+    __nirum_tag__ = HelloError.Tag.unknown
+    __nirum_tag_types__ = {}
+    __nirum_tag_names__ = name_dict_type([])
+
+    def __init__(self) -> None:
+        validate_union_type(self)
+
+    def __repr__(self) -> str:
+        return '{0}({1})'.format(
+            typing._type_repr(type(self)),
+            ', '.join('{}={}'.format(attr, getattr(self, attr))
+                      for attr in self.__slots__)
+        )
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, Unknown) and all(
+            getattr(self, attr) == getattr(other, attr)
+            for attr in self.__slots__
+        )
+
+    def __ne__(self, other) -> bool:
+        return not self == other
+
+    def __hash__(self) -> int:
+        return hash(self.__nirum_tag__)
+
+
+class BadRequest(HelloError):
+    # compiled code
+
+    __slots__ = ()
+    __nirum_tag__ = HelloError.Tag.bad_request
+    __nirum_tag_types__ = {}
+    __nirum_tag_names__ = name_dict_type([])
+
+    def __init__(self) -> None:
+        validate_union_type(self)
+
+    def __repr__(self) -> str:
+        return '{0}({1})'.format(
+            typing._type_repr(type(self)),
+            ', '.join('{}={}'.format(attr, getattr(self, attr))
+                      for attr in self.__slots__)
+        )
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, BadRequest) and all(
+            getattr(self, attr) == getattr(other, attr)
+            for attr in self.__slots__
+        )
+
+    def __ne__(self, other) -> bool:
+        return not self == other
+
+    def __hash__(self) -> int:
+        return hash(self.__nirum_tag__)
+
+
 class MusicService(Service):
 
     __nirum_service_methods__ = {
@@ -335,6 +428,9 @@ class MusicService(Service):
         ('get_artist_by_music', 'find_artist'),
         ('raise_application_error_request', 'raise_application_error_request'),
     ])
+    __nirum_method_error_types__ = {
+        'get_music_by_artist_name': HelloError
+    }
 
     def get_music_by_artist_name(self, artist_name):
         raise NotImplementedError('get_music_by_artist_name')

--- a/tests/rpc_test.py
+++ b/tests/rpc_test.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 
 from pytest import fixture, raises, mark
@@ -6,7 +7,8 @@ from werkzeug.test import Client as TestClient
 from werkzeug.wrappers import Response
 
 from nirum.exc import (InvalidNirumServiceMethodTypeError,
-                       InvalidNirumServiceMethodNameError)
+                       InvalidNirumServiceMethodNameError,
+                       UnexpectedNirumResponseError)
 from nirum.rpc import Client, WsgiApp
 from nirum.test import MockOpener
 
@@ -24,6 +26,10 @@ class MusicServiceImpl(nf.MusicService):
     }
 
     def get_music_by_artist_name(self, artist_name):
+        if artist_name == 'error':
+            raise nf.Unknown()
+        elif artist_name not in self.music_map:
+            raise nf.BadRequest()
         return self.music_map.get(artist_name)
 
     def incorrect_return(self):
@@ -325,3 +331,23 @@ def test_rpc_client_make_request(method_name, monkeypatch):
             },
             payload
         )
+
+
+@contextlib.contextmanager
+def assert_error(error_type):
+    try:
+        yield
+    except UnexpectedNirumResponseError as e:
+        response_json = json.loads(str(e))
+        assert response_json == error_type().__nirum_serialize__()
+    else:
+        assert False  # MUST error raised
+
+
+def test_rpc_error_types():
+    url = u'http://foobar.com/rpc/'
+    client = nf.MusicServiceClient(url, MockOpener(url, MusicServiceImpl))
+    with assert_error(nf.Unknown):
+        client.get_music_by_artist_name('error')
+    with assert_error(nf.BadRequest):
+        client.get_music_by_artist_name('adele')

--- a/tests/rpc_test.py
+++ b/tests/rpc_test.py
@@ -91,20 +91,6 @@ def assert_response(response, status_code, expect_json):
     assert actual_response_json == expect_json
 
 
-def test_rpc_internal_error(fx_test_client):
-    response = fx_test_client.post('/?method=raise_application_error_request')
-    assert response.status_code == 500, response.get_data(as_text=True)
-    actual_response_json = json.loads(
-        response.get_data(as_text=True)
-    )
-    expected_json = {
-        '_type': 'error',
-        '_tag': 'internal_server_error',
-        'message': 'hello world'
-    }
-    assert actual_response_json == expected_json
-
-
 def test_wsgi_app_error(fx_test_client):
     # method not allowed
     assert_response(


### PR DESCRIPTION
Catch method error type defined in `__nirum_method_error_types__`, otherwise raise it. close #71 