### PR TITLE
Build universal wheels (second attempt)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Version 0.5.1
 
 To be released.
 
+- Wheel distributions (``nirum-*.whl``) are now universal between Python 2
+  and 3.  [:issue:`78`]
+
 
 Version 0.5.0
 -------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
Reopened from #77.

Currently [nirum-python on PyPI][1] lacks a wheel for Python 3.  As it shares the same code between Python 2 and 3, wheels for it can be universal.

[1]: https://pypi.python.org/pypi/nirum