### PR TITLE
Fix syntax errors on changelog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ script:
   - pip install 'typing<3.5.2' && py.test tests -v
   - rst2html.py --strict CHANGES.rst
   - rst2html.py --strict README.rst
+  - python setup.py --long-description | rst2html.py --strict
   - |
       if [ -z "$(git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep CHANGES\.rst)" ]; then
         exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,13 @@ python:
   - 3.4
   - 3.5
 install:
-  - pip install -U pip setuptools
+  - pip install -U pip setuptools docutils
   - pip install -e .[tests]
 script:
   - py.test tests -v
   - pip install 'typing<3.5.2' && py.test tests -v
+  - rst2html.py --strict CHANGES.rst
+  - rst2html.py --strict README.rst
   - |
       if [ -z "$(git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep CHANGES\.rst)" ]; then
         exit 1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,15 +7,18 @@ Version 0.5.1
 To be released.
 
 - Wheel distributions (``nirum-*.whl``) are now universal between Python 2
-  and 3.  [:issue:`78`]
+  and 3.  [`#78`_]
 - ``nirum.rpc.Client`` and its subtype became to raise ``TypeError`` with
   a better error message when its ``make_request()`` method is overridden and
-  it returns a wrong artity of tuple.  [:issue:`80`]
+  it returns a wrong artity of tuple.  [`#80`_]
 - ``nirum.rpc.WsgiApp`` and its subtype became to raise ``TypeError`` with
   a better error message when its ``make_response()`` method is overridden and
-  it returns a wrong artity of tuple.  [:issue:`80`]
+  it returns a wrong artity of tuple.  [`#80`_]
 - Fixed a bug that ``Client.ping()`` method had always raised ``TypeError``.
-  [:issue:`80`]
+  [`#80`_]
+
+.. _#78: https://github.com/spoqa/nirum-python/pull/78
+.. _#80: https://github.com/spoqa/nirum-python/pull/80
 
 
 Version 0.5.0
@@ -23,8 +26,10 @@ Version 0.5.0
 
 Release on June 1, 2017.
 
-- Service methods became able to specify its error type. [:issue:`71`]
+- Service methods became able to specify its error type. [`#71`_]
 - Added ``nirum-server`` command to run simply Nirum service.
+
+.. _#71: https://github.com/spoqa/nirum-python/issues/71
 
 
 Version 0.4.1
@@ -32,7 +37,7 @@ Version 0.4.1
 
 Release on May 2, 2017.
 
-- Compare type with its abstract type in :func:`nirum.validate.validate_type`.
+- Compare type with its abstract type in ``nirum.validate.validate_type``.
 
 
 Version 0.4.0
@@ -41,15 +46,15 @@ Version 0.4.0
 Release on March 20, 2017.
 
 - Encoding of map types was changed according to the `Nirum serialization
-  specification`__.  [:issue:`66`]
-- Added :mod:`nirum.datastructures` module and
-  :class:`~nirum.datastructures.Map` which is an immutable dictionary.
-  [:issue:`66`]
-- Added :class:`nirum.datastructures.List` which is an immutable list.
-  [:issue:`49`]
-- Aliased :class:`~nirum.datastructures.Map` as ``map_type``, and
-  :class:`~nirum.datastructures.List` as ``list_type`` to avoid name
+  specification`__.  [`#66`_]
+- Added ``nirum.datastructures`` module and ``nirum.datastructures.Map``
+  which is an immutable dictionary.  [`#66`_]
+- Added ``nirum.datastructures.List`` which is an immutable list.
+  [`#49`_]
+- Aliased ``nirum.datastructures.Map`` as ``map_type``, and
+  ``nirum.datastructures.List`` as ``list_type`` to avoid name
   conflict with user-defined types.
 
-
+.. _#66: https://github.com/spoqa/nirum-python/pull/66
+.. _#49: https://github.com/spoqa/nirum-python/issues/49
 __ https://github.com/spoqa/nirum/blob/f1629787f45fef17eeab8b4f030c34580e0446b8/docs/serialization.md

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,19 @@
 import ast
+import re
 import sys
 
 from setuptools import find_packages, setup,  __version__ as setuptools_version
 
 
-def readme():
+def readme(name='README.rst'):
     try:
-        with open('README.rst') as f:
-            return f.read()
+        with open(name) as f:
+            rst = f.read()
+        return re.sub(
+            r'(^|\n).. include::\s*([^\n]+)($|\n)',
+            lambda m: m.group(1) + (readme(m.group(2)) or '') + m.group(3),
+            rst
+        )
     except (IOError, OSError):
         return
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,4 @@ deps = docutils
 commands =
     rst2html.py --strict CHANGES.rst
     rst2html.py --strict README.rst
+    python3 setup.py --long-description | rst2html.py --strict

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,14 @@
 [tox]
-envlist = py27,py34,py35
+envlist = py27,py34,py35,docs
 
 [testenv]
 deps = -e.[tests]
 commands=
     py.test -v tests
+
+[testenv:docs]
+basepython = python3
+deps = docutils
+commands =
+    rst2html.py --strict CHANGES.rst
+    rst2html.py --strict README.rst


### PR DESCRIPTION
- Fixed several RST syntax errors on changelog.
- Added a simple checker for RST files using docutils' `--strict` option.
- As PyPI doesn't process `.. include::` directive, made setup.py to manually process the directive to generate `--long-description` output.