### PR TITLE
Python 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: python
-python:
-  - 2.7
-  - 3.4
-  - 3.5
+python: [2.7, 3.4, 3.5, 3.6]
 install: pip install tox-travis
 script:
 - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ install:
   - pip install -U pip setuptools docutils
   - pip install -e .[tests]
 script:
-  - pytest tests -v
-  - pip install 'typing<3.5.2' && pytest tests -v
+  - pytest -v
+  - pip install 'typing<3.5.2' && pytest -v
   - rst2html.py --strict CHANGES.rst
   - rst2html.py --strict README.rst
   - python setup.py --long-description | rst2html.py --strict

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,8 @@ python:
   - 2.7
   - 3.4
   - 3.5
-install:
-  - pip install -U pip setuptools docutils
-  - pip install -e .[tests]
+install: pip install tox-travis
 script:
-  - pytest -v
-  - pip install 'typing<3.5.2' && pytest -v
-  - rst2html.py --strict CHANGES.rst
-  - rst2html.py --strict README.rst
-  - python setup.py --long-description | rst2html.py --strict
-  - |
-      if [ -z "$(git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep CHANGES\.rst)" ]; then
-        exit 1
-      fi
+- tox
+- tox -e docs
+- git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep CHANGES\.rst

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ install:
   - pip install -U pip setuptools docutils
   - pip install -e .[tests]
 script:
-  - py.test tests -v
-  - pip install 'typing<3.5.2' && py.test tests -v
+  - pytest tests -v
+  - pip install 'typing<3.5.2' && pytest tests -v
   - rst2html.py --strict CHANGES.rst
   - rst2html.py --strict README.rst
   - python setup.py --long-description | rst2html.py --strict

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Version 0.5.1
 
 To be released.
 
+- Added Python 3.6 support.
 - Wheel distributions (``nirum-*.whl``) are now universal between Python 2
   and 3.  [`#78`_]
 - ``nirum.rpc.Client`` and its subtype became to raise ``TypeError`` with

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 nirum-python
 ============
 
-Python rumtime for Nirum_ IDL.  Distributed under MIT license.
+The Nirum_ runtime library for Python.  Distributed under MIT license.
 
 (You probably don't need directly use this package.)
 

--- a/lint.sh
+++ b/lint.sh
@@ -2,7 +2,3 @@
 set -e
 
 flake8 .
-
-if [[ "$(python -c "import sys;print(sys.version[0])")" != "2" ]]; then
-  import-order nirum ./nirum
-fi

--- a/nirum/deserialize.py
+++ b/nirum/deserialize.py
@@ -13,8 +13,8 @@ import uuid
 from iso8601 import iso8601, parse_date
 from six import text_type
 
-from .datastructures import Map
 from ._compat import get_tuple_param_types, get_union_types, is_union_type
+from .datastructures import Map
 
 __all__ = (
     'deserialize_abstract_type',

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ else:
 setup(
     name='nirum',
     version=get_version(),
-    description='',
+    description='The Nirum runtime library for Python',
     long_description=readme(),
     url='https://github.com/spoqa/nirum-python',
     author='Kang Hyojun',

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,8 @@ install_requires = [
 ] + service_requires
 tests_require = [
     'pytest >= 3.1.2, < 4.0.0',
+    'pytest-flake8 >= 0.8.1, < 1.0.0',
     'import-order',
-    'flake8',
-    'tox',
 ]
 docs_require = [
     'Sphinx',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import ast
 import re
 import sys
 
-from setuptools import find_packages, setup,  __version__ as setuptools_version
+from setuptools import find_packages, setup, __version__ as setuptools_version
 
 
 def readme(name='README.rst'):

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ install_requires = [
 tests_require = [
     'pytest >= 3.1.2, < 4.0.0',
     'pytest-flake8 >= 0.8.1, < 1.0.0',
-    'import-order',
+    'flake8-import-order >= 0.12, < 1.0',
+    'flake8-import-order-spoqa >= 1.0.0, < 2.0.0',
 ]
 docs_require = [
     'Sphinx',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ install_requires = [
     'six', 'iso8601',
 ] + service_requires
 tests_require = [
-    'pytest >= 2.9.0',
+    'pytest >= 3.1.2, < 4.0.0',
     'import-order',
     'flake8',
     'tox',

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Internet :: WWW/HTTP :: WSGI :: Application',
         'Topic :: Software Development :: Code Generators',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/setup.py
+++ b/setup.py
@@ -92,5 +92,17 @@ setup(
     },
     setup_requires=setup_requires,
     extras_require=extras_require,
-    classifiers=[]
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Topic :: Internet :: WWW/HTTP :: WSGI :: Application',
+        'Topic :: Software Development :: Code Generators',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Topic :: Software Development :: Object Brokering',
+    ]
 )

--- a/tests/compat_test.py
+++ b/tests/compat_test.py
@@ -3,6 +3,7 @@ import typing
 
 from pytest import mark
 from six import text_type
+
 from nirum._compat import (get_abstract_param_types,
                            get_tuple_param_types,
                            get_union_types,

--- a/tests/deserialize_test.py
+++ b/tests/deserialize_test.py
@@ -2,18 +2,18 @@ import collections
 import datetime
 import decimal
 import numbers
-import uuid
 import typing
+import uuid
 
 from pytest import raises, mark
 from six import PY3, text_type
 
 from nirum._compat import utc
-from nirum.serialize import serialize_record_type
 from nirum.deserialize import (deserialize_unboxed_type, deserialize_meta,
                                deserialize_tuple_type,
                                deserialize_record_type, deserialize_union_type,
                                deserialize_optional, deserialize_primitive)
+from nirum.serialize import serialize_record_type
 
 
 def test_deserialize_unboxed_type(fx_unboxed_type, fx_token_type):

--- a/tests/func_test.py
+++ b/tests/func_test.py
@@ -7,8 +7,8 @@ from nirum.func import import_string
 
 def test_import_string():
     assert import_string('collections:OrderedDict') == collections.OrderedDict
-    assert import_string('collections:OrderedDict({"a": 1})') == \
-            collections.OrderedDict({"a": 1})
+    assert (import_string('collections:OrderedDict({"a": 1})') ==
+            collections.OrderedDict({"a": 1}))
     with raises(ValueError):
         # malformed
         import_string('world')

--- a/tests/py2_nirum.py
+++ b/tests/py2_nirum.py
@@ -1,21 +1,21 @@
-import enum
-import typing
 import decimal
+import enum
 import json
+import typing
 import uuid
 
 from six import text_type
 
-from nirum.serialize import (serialize_record_type, serialize_unboxed_type,
-                             serialize_meta, serialize_union_type)
+from nirum.constructs import NameDict, name_dict_type
 from nirum.deserialize import (deserialize_record_type,
                                deserialize_unboxed_type,
                                deserialize_meta,
                                deserialize_union_type)
+from nirum.rpc import Client, Service
+from nirum.serialize import (serialize_record_type, serialize_unboxed_type,
+                             serialize_meta, serialize_union_type)
 from nirum.validate import (validate_unboxed_type, validate_record_type,
                             validate_union_type)
-from nirum.constructs import NameDict, name_dict_type
-from nirum.rpc import Client, Service
 
 
 class Offset(object):

--- a/tests/py3_nirum.py
+++ b/tests/py3_nirum.py
@@ -1,19 +1,19 @@
-import enum
-import typing
 import decimal
+import enum
 import json
+import typing
 import uuid
 
-from nirum.serialize import (serialize_record_type, serialize_unboxed_type,
-                             serialize_meta, serialize_union_type)
+from nirum.constructs import NameDict, name_dict_type
 from nirum.deserialize import (deserialize_record_type,
                                deserialize_unboxed_type,
                                deserialize_meta,
                                deserialize_union_type)
+from nirum.rpc import Client, Service
+from nirum.serialize import (serialize_record_type, serialize_unboxed_type,
+                             serialize_meta, serialize_union_type)
 from nirum.validate import (validate_unboxed_type, validate_record_type,
                             validate_union_type)
-from nirum.constructs import NameDict, name_dict_type
-from nirum.rpc import Client, Service
 
 
 class Offset:

--- a/tests/rpc_test.py
+++ b/tests/rpc_test.py
@@ -6,13 +6,12 @@ from six import text_type
 from werkzeug.test import Client as TestClient
 from werkzeug.wrappers import Response
 
+from .nirum_schema import import_nirum_fixture
 from nirum.exc import (InvalidNirumServiceMethodTypeError,
                        InvalidNirumServiceMethodNameError,
                        UnexpectedNirumResponseError)
 from nirum.rpc import Client, WsgiApp
 from nirum.test import MockOpener
-
-from .nirum_schema import import_nirum_fixture
 
 
 nf = import_nirum_fixture()

--- a/tests/serialize_test.py
+++ b/tests/serialize_test.py
@@ -4,10 +4,10 @@ import uuid
 
 from pytest import mark
 
+from .nirum_schema import import_nirum_fixture
 from nirum._compat import utc
 from nirum.serialize import (serialize_unboxed_type, serialize_record_type,
                              serialize_meta, serialize_union_type)
-from .nirum_schema import import_nirum_fixture
 
 
 nirum_fixture = import_nirum_fixture()

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py27,py34,py35,docs
 [testenv]
 deps = -e.[tests]
 commands=
-    pytest -v tests
+    pytest -v
 
 [testenv:docs]
 basepython = python3
@@ -13,3 +13,9 @@ commands =
     rst2html.py --strict CHANGES.rst
     rst2html.py --strict README.rst
     python3 setup.py --long-description | rst2html.py --strict
+
+[pytest]
+addopts = --ff --flake8
+
+[flake8]
+exclude = .env, .tox, tests/py2_nirum.py, tests/py3_nirum.py

--- a/tox.ini
+++ b/tox.ini
@@ -19,3 +19,5 @@ addopts = --ff --flake8
 
 [flake8]
 exclude = .env, .tox, tests/py2_nirum.py, tests/py3_nirum.py
+import-order-style = spoqa
+application-import-names = nirum, tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35}-{typing351,typing352},docs
+envlist = {py27,py34,py35,py36}-{typing351,typing352},docs
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,11 @@
 [tox]
-envlist = py27,py34,py35,docs
+envlist = {py27,py34,py35}-{typing351,typing352},docs
 
 [testenv]
-deps = -e.[tests]
+deps =
+    -e.[tests]
+    typing351: typing<3.5.2
+    typing352: typing>=3.5.2
 commands=
     pytest -v
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py27,py34,py35,docs
 [testenv]
 deps = -e.[tests]
 commands=
-    py.test -v tests
+    pytest -v tests
 
 [testenv:docs]
 basepython = python3


### PR DESCRIPTION
- Simplified and reduced the duplicated testing configuration code using pytest-flake8 and tox-travis.
- Replace import-order with flake8-import-order-spoqa.
- Add missing classifiers to PyPI metadata.
- Add Python 3.6 support.