### PR TITLE
Make Client to process method error types properly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Version 0.5.1
 To be released.
 
 - Added Python 3.6 support.
+- Fixed a bug that service client methods hadn't raised the proper error
+  type but ``nirum.exc.UnexpectedNirumResponseError`` instead.  [`#71`_]
 - Wheel distributions (``nirum-*.whl``) are now universal between Python 2
   and 3.  [`#78`_]
 - ``nirum.rpc.Service`` had been an old-style class on Python 2, but now

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ To be released.
 - Added Python 3.6 support.
 - Wheel distributions (``nirum-*.whl``) are now universal between Python 2
   and 3.  [`#78`_]
+- ``nirum.rpc.Service`` had been an old-style class on Python 2, but now
+  it became a new-style class also on Python 2.  (As Python 3 has only new-style
+  class, there's no change on Python 3.)  [`#83`_]
 - ``nirum.rpc.Client`` and its subtype became to raise ``TypeError`` with
   a better error message when its ``make_request()`` method is overridden and
   it returns a wrong artity of tuple.  [`#80`_]
@@ -21,6 +24,7 @@ To be released.
   ``Accept``.
 
 .. _#78: https://github.com/spoqa/nirum-python/pull/78
+.. _#83: https://github.com/spoqa/nirum-python/issues/83
 .. _#80: https://github.com/spoqa/nirum-python/pull/80
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ To be released.
   it returns a wrong artity of tuple.  [`#80`_]
 - Fixed a bug that ``Client.ping()`` method had always raised ``TypeError``.
   [`#80`_]
+- Corrected a typo ``Accepts`` on request headers ``Client`` makes to
+  ``Accept``.
 
 .. _#78: https://github.com/spoqa/nirum-python/pull/78
 .. _#80: https://github.com/spoqa/nirum-python/pull/80

--- a/nirum/rpc.py
+++ b/nirum/rpc.py
@@ -32,7 +32,7 @@ JSONType = typing.Mapping[
 ]
 
 
-class Service:
+class Service(object):
     """Nirum RPC service."""
 
     __nirum_service_methods__ = {}

--- a/nirum/rpc.py
+++ b/nirum/rpc.py
@@ -342,7 +342,7 @@ class Client:
             request_url,
             [
                 ('Content-type', 'application/json;charset=utf-8'),
-                ('Accepts', 'application/json'),
+                ('Accept', 'application/json'),
             ],
             payload
         )

--- a/nirum/test.py
+++ b/nirum/test.py
@@ -1,3 +1,4 @@
+import email
 import socket
 
 from six import PY3
@@ -18,6 +19,9 @@ class MockHttpResponse(HTTPResponse):
     def __init__(self, body, status_code):
         self.body = body
         self.code = status_code
+        self.headers = email.message_from_string(
+            'Content-Type: application/json\n'
+        )
         if PY3:
             self.status = status_code
 

--- a/tests/rpc_test.py
+++ b/tests/rpc_test.py
@@ -1,4 +1,3 @@
-import contextlib
 import json
 
 from pytest import fixture, raises, mark
@@ -8,8 +7,7 @@ from werkzeug.wrappers import Response
 
 from .nirum_schema import import_nirum_fixture
 from nirum.exc import (InvalidNirumServiceMethodTypeError,
-                       InvalidNirumServiceMethodNameError,
-                       UnexpectedNirumResponseError)
+                       InvalidNirumServiceMethodNameError)
 from nirum.rpc import Client, WsgiApp
 from nirum.test import MockOpener
 
@@ -354,21 +352,10 @@ def test_client_make_request_arity_check(arity):
     )
 
 
-@contextlib.contextmanager
-def assert_error(error_type):
-    try:
-        yield
-    except UnexpectedNirumResponseError as e:
-        response_json = json.loads(str(e))
-        assert response_json == error_type().__nirum_serialize__()
-    else:
-        assert False  # MUST error raised
-
-
 def test_rpc_error_types():
     url = u'http://foobar.com/rpc/'
     client = nf.MusicServiceClient(url, MockOpener(url, MusicServiceImpl))
-    with assert_error(nf.Unknown):
+    with raises(nf.Unknown):
         client.get_music_by_artist_name('error')
-    with assert_error(nf.BadRequest):
+    with raises(nf.BadRequest):
         client.get_music_by_artist_name('adele')


### PR DESCRIPTION
`Client` hadn't properly dealt with method error types (#71 and spoqa/nirum#38).  This patch fixes it and other related bugs. See also the changelog.