### PR TITLE
`url` now can be both `str` and `unicode`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ Version 0.5.2
 
 To be released.
 
+- URL & method could be both unicode and str on python2.7. [`#87_`]
+
+.. _#87: https://github.com/spoqa/nirum-python/pull/87
+
 
 Version 0.5.1
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@ Version 0.5.2
 
 To be released.
 
-- URL & method could be both unicode and str on python2.7. [`#87_`]
+- ``url`` of ``nirum.rpc.Client`` and
+  ``method`` of ``nirum.rpc.Client.make_request``
+  could be both unicode and str on python2.7. [`#87`_]
 
 .. _#87: https://github.com/spoqa/nirum-python/pull/87
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ To be released.
 - ``url`` of ``nirum.rpc.Client`` and
   ``method`` of ``nirum.rpc.Client.make_request``
   now can be both ``unicode`` and ``str`` on Python 2.7. [`#87`_]
+- ``nirum.rpc.Client`` had been an old-style class on Python 2, but now
+  it became a new-style class also on Python 2. (As Python 3 has only new-style
+  class, there's no change on Python 3.)
 
 .. _#87: https://github.com/spoqa/nirum-python/pull/87
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ To be released.
 
 - ``url`` of ``nirum.rpc.Client`` and
   ``method`` of ``nirum.rpc.Client.make_request``
-  could be both unicode and str on python2.7. [`#87`_]
+  now can be both ``unicode`` and ``str`` on Python 2.7. [`#87`_]
 
 .. _#87: https://github.com/spoqa/nirum-python/pull/87
 

--- a/nirum/rpc.py
+++ b/nirum/rpc.py
@@ -7,7 +7,7 @@ import collections
 import json
 import typing
 
-from six import integer_types, text_type
+from six import integer_types, string_types
 from six.moves import urllib
 from werkzeug.exceptions import HTTPException
 from werkzeug.http import HTTP_STATUS_CODES
@@ -313,7 +313,7 @@ class WsgiApp:
         return WsgiResponse(content, status_code, headers, **kwargs)
 
 
-class Client:
+class Client(object):
 
     def __init__(self, url, opener=urllib.request.build_opener()):
         self.url = url_endswith_slash(url)
@@ -375,9 +375,9 @@ class Client:
                 repr(request_tuple)
             )
         http_method, request_url, headers, content = request_tuple
-        if not isinstance(request_url, text_type):
+        if not isinstance(request_url, string_types):
             raise TypeError(
-                '`request_url` have to be instance of text. not {}'.format(
+                '`request_url` have to be instance of string. not {}'.format(
                     typing._type_repr(type(request_url))
                 )
             )
@@ -393,9 +393,9 @@ class Client:
                     typing._type_repr(type(content))
                 )
             )
-        if not isinstance(http_method, text_type):
+        if not isinstance(http_method, string_types):
             raise TypeError(
-                '`method` have to be instance of text. not {}'.format(
+                '`method` have to be instance of string. not {}'.format(
                     typing._type_repr(type(http_method))
                 )
             )

--- a/tests/rpc_test.py
+++ b/tests/rpc_test.py
@@ -54,6 +54,19 @@ class MusicServiceTypeErrorImpl(nf.MusicService):
     get_music_by_artist_name = 1
 
 
+class MethodClient(Client):
+
+    def __init__(self, method, url, opener):
+        self.method = method
+        super(MethodClient, self).__init__(url, opener)
+
+    def make_request(self, _, request_url, headers, payload):
+        return (
+            self.method, request_url, headers,
+            json.dumps(payload).encode('utf-8')
+        )
+
+
 @mark.parametrize('impl, error_class', [
     (MusicServiceNameErrorImpl, InvalidNirumServiceMethodNameError),
     (MusicServiceTypeErrorImpl, InvalidNirumServiceMethodTypeError),
@@ -333,6 +346,23 @@ def test_rpc_client_make_request(method_name):
 def test_client_ping():
     url = u'http://foobar.com/rpc/'
     client = Client(url, MockOpener(url, MusicServiceImpl))
+    assert client.ping()
+
+
+@mark.parametrize(
+    'url',
+    [u'http://foobar.com/rpc/', 'http://foobar.com/rpc/']
+)
+def test_client_url(url):
+    client = Client(url, MockOpener(url, MusicServiceImpl))
+    assert client.ping()
+
+
+@mark.parametrize('method', [u'POST', 'POST'])
+def test_client_make_request_method_type(method):
+    url = 'http://test.com'
+    client = MethodClient(method, url,
+                          MockOpener(url, MusicServiceImpl))
     assert client.ping()
 
 


### PR DESCRIPTION
Resolve https://github.com/spoqa/nirum-python/issues/69.