### PR TITLE
Make serialize_meta() to properly reduce set/like-like types other than built-in set/list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ To be released.
 - Fixed a serialization bug that other set-like (i.e. ``collections.Set``) types
   than Python built-in ``set`` hadn't been reduced to simpler forms so that they
   can be encoded to JSON.
+- Fixed a serialization bug that other list-like (i.e. ``collections.Sequence``)
+  types than Python built-in ``list`` hadn't been reduced to simpler forms so
+  that they can be encoded to JSON.
 
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+Version 0.4.2
+-------------
+
+To be released.
+
+- Fixed a serialization bug that other set-like (i.e. ``collections.Set``) types
+  than Python built-in ``set`` hadn't been reduced to simpler forms so that they
+  can be encoded to JSON.
+
+
+
 Version 0.4.1
 -------------
 

--- a/nirum/serialize.py
+++ b/nirum/serialize.py
@@ -66,7 +66,7 @@ def serialize_meta(data):
         d = data.isoformat()
     elif isinstance(data, decimal.Decimal) or isinstance(data, uuid.UUID):
         d = str(data)
-    elif isinstance(data, set) or isinstance(data, list):
+    elif isinstance(data, collections.Set) or isinstance(data, list):
         d = [serialize_meta(e) for e in data]
     elif isinstance(data, collections.Mapping):
         d = [

--- a/nirum/serialize.py
+++ b/nirum/serialize.py
@@ -7,6 +7,8 @@ import datetime
 import decimal
 import uuid
 
+from six import string_types
+
 __all__ = (
     'serialize_boxed_type', 'serialize_meta',
     'serialize_record_type', 'serialize_unboxed_type',
@@ -59,14 +61,18 @@ def serialize_union_type(data):
 def serialize_meta(data):
     if hasattr(data, '__nirum_serialize__'):
         d = data.__nirum_serialize__()
-    elif type(data) in {str, float, bool, int}:
+    elif isinstance(data, (string_types, bool, int, float)):
+        # FIXME: str in py2 represents binary string as well as text string.
+        # It should be refactored so that the function explicitly takes
+        # an expected type as like deserialize_meta() does.
         d = data
     elif (isinstance(data, datetime.datetime) or
             isinstance(data, datetime.date)):
         d = data.isoformat()
     elif isinstance(data, decimal.Decimal) or isinstance(data, uuid.UUID):
         d = str(data)
-    elif isinstance(data, collections.Set) or isinstance(data, list):
+    elif (isinstance(data, collections.Set) or
+          isinstance(data, collections.Sequence)):
         d = [serialize_meta(e) for e in data]
     elif isinstance(data, collections.Mapping):
         d = [

--- a/tests/serialize_test.py
+++ b/tests/serialize_test.py
@@ -101,6 +101,8 @@ def test_serialize_meta_set_of_record(fx_record_type, fx_unboxed_type,
     serialize_result = serialize_meta({record, record2})
     assert record.__nirum_serialize__() in serialize_result
     assert record2.__nirum_serialize__() in serialize_result
+    assert (sorted(serialize_meta(frozenset([record, record2])), key=repr) ==
+            sorted(serialize_result, key=repr))
 
 
 def test_serialize_meta_map(fx_point):

--- a/tests/serialize_test.py
+++ b/tests/serialize_test.py
@@ -5,6 +5,7 @@ import uuid
 from pytest import mark
 
 from nirum._compat import utc
+from nirum.datastructures import List
 from nirum.serialize import (serialize_unboxed_type, serialize_record_type,
                              serialize_meta, serialize_union_type)
 from .nirum_schema import import_nirum_fixture
@@ -92,6 +93,17 @@ def test_serialize_meta_set(d, expect):
     serialized = serialize_meta(d)
     for e in expect:
         e in serialized
+
+
+def test_serialize_meta_list(fx_record_type, fx_unboxed_type, fx_offset):
+    record = fx_record_type(fx_offset, fx_offset)
+    record2 = fx_record_type(fx_unboxed_type(1.1), fx_unboxed_type(1.2))
+    serialize_result = serialize_meta([record, record2])
+    assert serialize_result == [
+        {'_type': 'point', 'x': 1.2, 'top': 1.2},
+        {'_type': 'point', 'x': 1.1, 'top': 1.2},
+    ]
+    assert serialize_meta(List([record, record2])) == serialize_result
 
 
 def test_serialize_meta_set_of_record(fx_record_type, fx_unboxed_type,


### PR DESCRIPTION
The detail explanation is written down in the changelog.  I'm going to port this fix to maintenance-0.5 and master branches as well.