### PR TITLE
Fix changelog test run by tag builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
     if git show --format=%B --quiet "$TRAVIS_COMMIT_RANGE$TRAVIS_TAG" | grep '\[changelog skip\]' > /dev/null; then
       echo "Skip changelog checker..."
     elif [[ "$TRAVIS_TAG" != "" ]]; then
-      ! grep -i "to be released" README.rst
+      ! grep -i "to be released" CHANGES.rst
     else
       [[ "$(git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep CHANGES\.rst)" != "" ]]
     fi


### PR DESCRIPTION
Tag builds had been failed due to changelog check on a wrong file.