### PR TITLE
Make Transport.call() to take multiple annotation arguments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ To be released.
 
 - ``nirum.rpc`` module and ``Client``, ``Service``, and ``WsgiApp`` in
   the module, had been deprecated since 0.6.0, are now completely obsolete.
+- Annotation parameters (``service_annotations``, ``method_annotations``, and
+  ``parameter_annotations``) of ``nirum.transport.Transport.call()`` method
+  now can take multiple arguments.
 
 
 Version 0.6.0

--- a/nirum/transport.py
+++ b/nirum/transport.py
@@ -32,21 +32,21 @@ class Transport(object):
             :class:`~typing.Sequence`, :class:`int`, :class:`float`,
             :class:`bool`, :const:`None`]]
         :param service_annotations: A mapping of annotations of the service.
-            The keys are normalized behind names of annotations.
-            The values are annotation value strings or :const:`None`
-            if an annotation has no value.
+            The keys are normalized names of annotations.
+            The values are mapping objects of annotation parameter names to
+            argument values.
         :type service_annotations: :class:`~typing.Mapping`\ [:class:`str`,
-            :class:`~typing.Optional`\ [:class:`str`]]
+            :class:`~typing.Mapping`\ [:class:`str`, :class:`str`]]
         :param method_annotations: A mapping of annotations of the method.
-            The keys are normalized behind names of annotations.
-            The values are annotation value strings or :const:`None`
-            if an annotation has no value.
+            The keys are normalized names of annotations.
+            The values are mapping objects of annotation parameter names to
+            argument values.
         :type method_annotations: :class:`~typing.Mapping`\ [:class:`str`,
-            :class:`~typing.Optional`\ [:class:`str`]]
+            :class:`~typing.Mapping`\ [:class:`str`, :class:`str`]]
         :param parameter_annotations: A mapping of parameter annotations.
             Its structure is similar to ``service_annotations`` and
             ``method_annotations`` except it's one more level nested.
-            The keys are normalized behind names of parameters.
+            The keys are normalized names of parameters.
             The values are the annotation mappings of their corresponding
             parameter.
         :type parameter_annotations: :class:`~typing.Mapping`\ [:class:`str`,

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,8 @@ install_requires = [
     'six', 'iso8601',
 ]
 tests_require = [
-    'pytest >= 3.1.2, < 4.0.0',
-    'pytest-flake8 >= 0.8.1, < 1.0.0',
+    'pytest >= 3.2.3, < 4.0.0',
+    'pytest-flake8 >= 0.9.1, < 1.0.0',
     'flake8-import-order >= 0.12, < 1.0',
     'flake8-import-order-spoqa >= 1.0.1, < 2.0.0',
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,6 @@ envlist = buildfixture,{py27,py34,py35,py36}-{typing351,typing352},docs
 
 [testenv]
 deps =
-    ; FIXME: the following command should be removed when
-    ; https://github.com/tholo/pytest-flake8/pull/35 is merged:
-    git+git://github.com/jezdez/pytest-flake8.git@flake8-3.5.0
-
     -e.[tests]
     typing351: typing<3.5.2
     typing352: typing>=3.5.2


### PR DESCRIPTION
This patch follows new annotation spec made by spoqa/nirum#190.