### PR TITLE
List shouldn't refer value

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Version 0.5.4
 
 To be released.
 
+- Made `nirum.datastructures.List` to copy the given value so that
+  it doesn't refer given value's state and is immutable.
+
 
 Version 0.5.3
 -------------

--- a/nirum/datastructures.py
+++ b/nirum/datastructures.py
@@ -54,7 +54,7 @@ class Map(collections.Mapping):
 class List(collections.Sequence):
 
     def __init__(self, items):
-        self.items = items
+        self.items = list(items)
 
     def __getitem__(self, index):
         return self.items[index]

--- a/tests/datastructures_test.py
+++ b/tests/datastructures_test.py
@@ -88,3 +88,12 @@ def test_list():
     assert immutable_list.count(1) == 1
     assert immutable_list.count(2) == 1
     assert immutable_list.count(3) == 0
+
+
+def test_list_immutable():
+    mutable_list = [1, 2]
+    immutable_list = List(mutable_list)
+    mutable_list.append(3)
+    assert immutable_list.items != mutable_list
+    assert immutable_list.items == [1, 2]
+    assert mutable_list == [1, 2, 3]


### PR DESCRIPTION
Related issue - https://github.com/spoqa/nirum-python/issues/104

`nirum.datastructures.List` is just proxy because `items` just referred in `List.__init__()`.  so i copy value when initialize attribute.