### PR TITLE
Ensure optional type include `None` type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,13 +6,15 @@ Version 0.6.2
 
 To be released.
 
+- Added ``is_optional_type()`` to ensure optional type includes ``None`` type.
+
 
 Version 0.6.1
 -------------
 
 Released on December 9, 2017.
 
-- Made `nirum.datastructures.List` to copy the given value so that
+- Made ``nirum.datastructures.List`` to copy the given value so that
   it doesn't refer given value's state and is immutable.
 
 

--- a/nirum/_compat.py
+++ b/nirum/_compat.py
@@ -1,7 +1,7 @@
 import datetime
 import typing
 
-__all__ = 'utc', 'is_union_type', 'get_union_types'
+__all__ = 'utc', 'is_optional_type', 'is_union_type', 'get_union_types'
 
 
 try:
@@ -41,6 +41,10 @@ else:
             return type_.__union_params__ \
                 if hasattr(type_, '__union_params__') \
                 else type_.__args__
+
+
+def is_optional_type(type_):
+    return is_union_type(type_) and type(None) in get_union_types(type_)
 
 
 def get_abstract_param_types(type_):

--- a/nirum/deserialize.py
+++ b/nirum/deserialize.py
@@ -13,7 +13,7 @@ import uuid
 from iso8601 import iso8601, parse_date
 from six import text_type
 
-from ._compat import get_tuple_param_types, get_union_types, is_union_type
+from ._compat import get_tuple_param_types, get_union_types, is_optional_type
 from .datastructures import Map
 
 __all__ = (
@@ -175,9 +175,9 @@ def deserialize_primitive(cls, data):
 
 
 def deserialize_optional(cls, data):
+    if not is_optional_type(cls):
+        raise ValueError('{!r} is not optional type'.format(cls))
     union_types = get_union_types(cls)
-    if not any(isinstance(None, ut) for ut in union_types):
-        raise ValueError(cls)
     if data is None:
         return data
     for union_type in union_types:
@@ -206,7 +206,7 @@ def deserialize_meta(cls, data):
         d = deserialize_tuple_type(cls, data)
     elif is_support_abstract_type(cls):
         d = deserialize_abstract_type(cls, data)
-    elif is_union_type(cls):
+    elif is_optional_type(cls):
         d = deserialize_optional(cls, data)
     elif callable(cls) and cls in _NIRUM_PRIMITIVE_TYPE:
         d = deserialize_primitive(cls, data)


### PR DESCRIPTION
Only Union type used in nirum-python is optional type . that is why``deserialize_meta`` could work well, even though we use `is_union_type` to find optional type.

But [comment](https://github.com/spoqa/nirum-python-wsgi/pull/7#discussion_r160142496) from other pull request suggest adding `is_optional_type` to ensure `None` is in it.

After we release nirum 0.6.2, replace `nirum._compat.is_optional_type` into `nirum_wsgi.is_optional_type`.