### PR TITLE
Fix two bugs of changelog checker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,11 @@ script:
 - tox -e docs
 - '[[ "$TRAVIS_TAG" = "" ]] || [[ "$TRAVIS_TAG" = "$(python setup.py --version)" ]]'
 - |
-    if git show --format=%B --quiet "$TRAVIS_COMMIT_RANGE$TRAVIS_TAG" | grep '\[changelog skip\]' > /dev/null; then
-      echo "Skip changelog checker..."
-    elif [[ "$TRAVIS_TAG" != "" ]]; then
-      ! grep -i "to be released" README.rst
-    else
-      [[ "$(git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep CHANGES\.rst)" != "" ]]
-    fi
+  if git show --format=%B --quiet "${TRAVIS_PULL_REQUEST_SHA:-${TRAVIS_TAG:-${TRAVIS_COMMIT}}}" \
+     | grep '\[changelog skip\]' > /dev/null; then
+    echo "Skip changelog checker..."
+  elif [[ "$TRAVIS_TAG" != "" ]]; then
+    ! grep -i "to be released" CHANGES.rst
+  else
+    [[ "$(git diff --name-only "$TRAVIS_COMMIT_RANGE" | grep CHANGES\.rst)" != "" ]]
+  fi


### PR DESCRIPTION
- “To be released” is usually appeared in CHANGES.rst, not README.rst.
- As `git show` doesn't work with `TRAVIS_COMMIT_RANGE` value when amended commit/rebased commits are pushed, it'd better to refer to `TRAVIS_PULL_REQUEST_SHA`/`TRAVIS_TAG`/`TRAVIS_COMMIT` for certain cases instead.