### PR TITLE
Representation of datastructures:List

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ Version 0.6.2
 To be released.
 
 - Added ``is_optional_type()`` to ensure optional type includes ``None`` type.
+- ``nirum.datastructures.List`` became to show its contents when it's passed
+  to ``repr()``.  [`#103`__, `#108`__ by Chang-soo Han]
+
+__ https://github.com/spoqa/nirum-python/issues/103
+__ https://github.com/spoqa/nirum-python/pull/108
 
 
 Version 0.6.1

--- a/nirum/datastructures.py
+++ b/nirum/datastructures.py
@@ -74,6 +74,10 @@ class List(collections.Sequence):
     def count(self, item):
         return self.items.count(item)
 
+    def __repr__(self):
+        args = repr(self.items)
+        return '{0.__module__}.{0.__name__}({1})'.format(type(self), args)
+
 
 map_type = Map
 list_type = List

--- a/tests/datastructures_test.py
+++ b/tests/datastructures_test.py
@@ -97,3 +97,9 @@ def test_list_immutable():
     assert immutable_list.items != mutable_list
     assert immutable_list.items == [1, 2]
     assert mutable_list == [1, 2, 3]
+
+
+def test_list_repr():
+    assert repr(List([])) == 'nirum.datastructures.List([])'
+    assert repr(List([1])) == 'nirum.datastructures.List([1])'
+    assert repr(List([1, 2])) == 'nirum.datastructures.List([1, 2])'


### PR DESCRIPTION
Implements `datastructurs:List.__repr__`.  Fixes #103.

@admire93 @dahlia